### PR TITLE
Style for error status

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -58,7 +58,7 @@ ul.pulls li.status {
 ul.pulls li.status.success {
     background-color: #39c5a0;
 }
-ul.pulls li.status.failure {
+ul.pulls li.status.failure, ul.pulls li.status.error {
     background-color: #ac3939;
 }
 ul.pulls li.status.pending {


### PR DESCRIPTION
There was no style given for PRs with the "error" status (A github status [can be one of pending, success, error, or failure](https://developer.github.com/v3/repos/statuses/)), this gives errors the same style as failures.
