### PR TITLE
Wall display

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Options :
   * *apiUrl* : url of your Github API (optional, default is `https://api.github.com`),
   * *token* : authorization token for API calls (optional, it can increase API rate limit).
   * *descendingOrder* : allow to change ordering of pull requests (optional, default is `true`).
+* **fetchAndDisplayTags** : fetch tags associated to pull requests for the wall display (makes more requests to the API)
 
 ## Run the server
 
@@ -61,6 +62,10 @@ Colors show the PR statuses :
 * *yellow* when the tests are running
 * *red* when tests fail
 * *green* when tests are successful
+
+Two different display options are available :
+* List
+* Wall-display
 
 ## Installation for dev
 

--- a/app/scripts/controllers/main.js
+++ b/app/scripts/controllers/main.js
@@ -6,6 +6,7 @@ angular.module('gtrApp')
     $scope.teams = config.teams;
     $scope.team  = team;
     $scope.wallDisplay = config.wallDisplay;
+    $scope.display = 'list';
 
     if (typeof(config.teams[team].descendingOrder) !== 'undefined') {
       $scope.descendingOrder = config.teams[team].descendingOrder;

--- a/app/scripts/controllers/main.js
+++ b/app/scripts/controllers/main.js
@@ -6,6 +6,7 @@ angular.module('gtrApp')
     $scope.teams = config.teams;
     $scope.team  = team;
     $scope.wallDisplay = config.wallDisplay;
+    $scope.fetchAndDisplayTags = config.fetchAndDisplayTags;
     $scope.display = localStorage.getItem('display') || 'list';
     $scope.$watch('display', function(displayValue) {
       localStorage.setItem('display', displayValue);

--- a/app/scripts/controllers/main.js
+++ b/app/scripts/controllers/main.js
@@ -6,7 +6,10 @@ angular.module('gtrApp')
     $scope.teams = config.teams;
     $scope.team  = team;
     $scope.wallDisplay = config.wallDisplay;
-    $scope.display = 'list';
+    $scope.display = localStorage.getItem('display') || 'list';
+    $scope.$watch('display', function(displayValue) {
+      localStorage.setItem('display', displayValue);
+    });
 
     if (typeof(config.teams[team].descendingOrder) !== 'undefined') {
       $scope.descendingOrder = config.teams[team].descendingOrder;

--- a/app/scripts/controllers/main.js
+++ b/app/scripts/controllers/main.js
@@ -5,7 +5,6 @@ angular.module('gtrApp')
     $scope.pulls = PullFetcher.pulls;
     $scope.teams = config.teams;
     $scope.team  = team;
-    $scope.wallDisplay = config.wallDisplay;
     $scope.fetchAndDisplayTags = config.fetchAndDisplayTags;
     $scope.display = localStorage.getItem('display') || 'list';
     $scope.$watch('display', function(displayValue) {
@@ -36,6 +35,7 @@ angular.module('gtrApp')
       var g = parseInt(bgcolor.substr(2,2),16);
       var b = parseInt(bgcolor.substr(4,2),16);
       var yiq = ((r*299)+(g*587)+(b*114))/1000;
+
       return yiq >= 128 ? '000' : 'fff';
     };
 

--- a/app/scripts/controllers/main.js
+++ b/app/scripts/controllers/main.js
@@ -5,6 +5,7 @@ angular.module('gtrApp')
     $scope.pulls = PullFetcher.pulls;
     $scope.teams = config.teams;
     $scope.team  = team;
+    $scope.wallDisplay = config.wallDisplay;
 
     if (typeof(config.teams[team].descendingOrder) !== 'undefined') {
       $scope.descendingOrder = config.teams[team].descendingOrder;
@@ -19,6 +20,18 @@ angular.module('gtrApp')
       });
 
       return array;
+    };
+
+    /**
+     * getVisibleTextColor gets black or white, visible with this background
+     * @type {string} bgcolor hexademical color, 6 chars (ex: "ffffff")
+     */
+    $scope.getVisibleTextColor = function(bgcolor) {
+      var r = parseInt(bgcolor.substr(0,2),16);
+      var g = parseInt(bgcolor.substr(2,2),16);
+      var b = parseInt(bgcolor.substr(4,2),16);
+      var yiq = ((r*299)+(g*587)+(b*114))/1000;
+      return yiq >= 128 ? '000' : 'fff';
     };
 
     $scope.$watch('team', function (team) {

--- a/app/scripts/services/pullFetcher.js
+++ b/app/scripts/services/pullFetcher.js
@@ -83,7 +83,9 @@ angular.module('gtrApp')
             var filtered = response.data.filter(filterPulls);
 
             return $q.all(filtered.map(addStatusToPull)).then(function() {
-              if (!config.fetchAndDisplayTags) { return; }
+              if (!config.fetchAndDisplayTags) {
+                return;
+              }
               return $q.all(filtered.map(addLabelsToPull));
             }).then(function() {
               return filtered;

--- a/app/scripts/services/pullFetcher.js
+++ b/app/scripts/services/pullFetcher.js
@@ -71,12 +71,20 @@ angular.module('gtrApp')
         });
       };
 
+      var addLabelsToPull = function (pull) {
+        return request(pull.issue_url).then(function (response) {
+          pull.labels = response.data.labels;
+        });
+      };
+
       var getRepoPulls = function (repo) {
         return request(repo.pulls_url.replace('{/number}', ''))
           .then(function (response) {
             var filtered = response.data.filter(filterPulls);
 
             return $q.all(filtered.map(addStatusToPull)).then(function() {
+              return $q.all(filtered.map(addLabelsToPull));
+            }).then(function() {
               return filtered;
             });
           });

--- a/app/scripts/services/pullFetcher.js
+++ b/app/scripts/services/pullFetcher.js
@@ -4,7 +4,7 @@ angular.module('gtrApp')
   .provider('PullFetcher', function () {
     var baseUrl = 'https://api.github.com';
 
-    this.$get = ['$http', '$q', function ($http, $q) {
+    this.$get = ['$http', '$q', 'config', function ($http, $q, config) {
 
       var currentTeam,
         currentApiUrl,
@@ -83,6 +83,7 @@ angular.module('gtrApp')
             var filtered = response.data.filter(filterPulls);
 
             return $q.all(filtered.map(addStatusToPull)).then(function() {
+              if (!config.fetchAndDisplayTags) { return; }
               return $q.all(filtered.map(addLabelsToPull));
             }).then(function() {
               return filtered;

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -1,3 +1,7 @@
+html, body {
+  height: 100%;
+}
+
 body {
   background-color: #ecf0f1;
   color: #efefef;
@@ -25,7 +29,7 @@ a {
 .header-top select {
   float: right;
   margin-right: 6px;
-} 
+}
 
 .header-users {
   background-color: #3cc0bf;
@@ -86,4 +90,58 @@ ul.pulls .repo {
 .clearer {
   line-height: 0;
   clear: both;
+}
+
+
+/**
+ * Overwrites for wall-display version
+ */
+
+body.wall-display {
+  margin: 0;
+  padding: 0;
+}
+
+.container.wall-display {
+  height: 100%;
+  padding: 0;
+}
+
+.wall-display ul.pulls {
+  display: flex;
+  flex-flow: row wrap;
+  height: 100%;
+}
+
+.wall-display ul.pulls li {
+  display: flex;
+  flex-grow: 1;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  box-sizing: border-box;
+  line-height: initial;
+  text-align: center;
+  margin: 0;
+  padding: 0;
+}
+
+.wall-display ul.pulls li .avatar {
+  border-radius: 50%;
+  height: 5.25em;
+  margin: 0;
+  padding: 0;
+}
+
+.wall-display .pull-number {
+  font-size: 4em;
+  font-weight: bold;
+}
+
+.wall-display .labels {
+  font-size: 1.5em;
+}
+
+.wall-display .repo {
+  font-size: 1.5em;
 }

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -132,7 +132,8 @@ body.wall-display {
   line-height: initial;
   text-align: center;
   margin: 0;
-  padding: 0;
+  padding: 0.5em;
+  border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
 .wall-display ul.pulls li .avatar {
@@ -152,5 +153,5 @@ body.wall-display {
 }
 
 .wall-display .repo {
-  font-size: 1.5em;
+  font-size: 1.2em;
 }

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -20,15 +20,24 @@ a {
   font-size: 13px;
   line-height: 20px;
   padding: 6px 16px;
+  display: flex;
+  flex-flow: row wrap;
+}
+
+.header-top div {
+  flex-grow: 1;
 }
 
 .header-top a {
   font-weight: bold;
 }
 
-.header-top select {
-  float: right;
-  margin-right: 6px;
+.header-top .team-choice {
+  text-align: right;
+}
+
+.header-top .display-choice {
+  text-align: center;
 }
 
 .header-users {

--- a/app/views/main.html
+++ b/app/views/main.html
@@ -26,7 +26,7 @@
     <ul class="pulls" ng-if="display === 'wallDisplay'">
         <li ng-repeat="pr in toArray(pulls) | orderBy:'updated_at':descendingOrder" ng-class="pr.statuses[0].state" class="status">
             <img class="avatar" ng-src="{{ pr.user.avatar_url}}" title="{{ pr.user.login }}" />
-            <div class="pull-number"><a ng-href="{{pr.html_url}}" >#{{ pr.number }}</a></div>
+            <div class="pull-number" title="{{pr.title}}"><a ng-href="{{pr.html_url}}" >#{{ pr.number }}</a></div>
             <div class="labels">
                 <span ng-if="!pr.labels.length">&nbsp;</span>
                 <span class="label" ng-repeat="label in pr.labels" ng-style="{'background-color': '#' + label.color, 'color': '#' + getVisibleTextColor(label.color)}">{{label.name}}</span>

--- a/app/views/main.html
+++ b/app/views/main.html
@@ -28,7 +28,7 @@
             <img class="avatar" ng-src="{{ pr.user.avatar_url}}" title="{{ pr.user.login }}" />
             <div class="pull-number" title="{{pr.title}}"><a ng-href="{{pr.html_url}}" >#{{ pr.number }}</a></div>
             <div class="labels">
-                <span ng-if="!pr.labels.length">&nbsp;</span>
+                <span ng-if="!pr.labels.length && fetchAndDisplayTags">&nbsp;</span>
                 <span class="label" ng-repeat="label in pr.labels" ng-style="{'background-color': '#' + label.color, 'color': '#' + getVisibleTextColor(label.color)}">{{label.name}}</span>
             </div>
             <div class="repo"><a ng-href="{{pr.head.repo.html_url}}" >{{ pr.head.repo.name }}</a></div>

--- a/app/views/main.html
+++ b/app/views/main.html
@@ -1,10 +1,18 @@
 <header class="header-top">
-  <a href="http://github.com/m6web/GithubTeamReviewer">Github Team Reviewer</a> by <a href="http://tech.m6web.fr">M6Web</a>
-  <select ng-model="team" ng-options="teamName as teamName for (teamName, team) in teams"></select>
+    <div class="link">
+        <a href="http://github.com/m6web/GithubTeamReviewer">Github Team Reviewer</a> by <a href="http://tech.m6web.fr">M6Web</a>
+    </div>
+    <div class="display-choice">
+        List <input type="radio" ng-model="display" value="list">
+        <input type="radio" ng-model="display" value="wallDisplay"> Wall Display
+    </div>
+    <div class="team-choice">
+        <select ng-model="team" ng-options="teamName as teamName for (teamName, team) in teams"></select>
+    </div>
 </header>
 
-<div class="container" ng-class="{'wall-display': wallDisplay}">
-    <ul class="pulls" ng-if="!wallDisplay">
+<div class="container" ng-class="{'wall-display': display === 'wallDisplay'}">
+    <ul class="pulls" ng-if="display === 'list'">
         <li ng-repeat="pr in toArray(pulls) | orderBy:'updated_at':descendingOrder" ng-class="pr.statuses[0].state" class="status">
             <span class="link"><img class="avatar" ng-src="{{ pr.user.avatar_url}}" title="{{ pr.user.login }}" /><a ng-href="{{pr.html_url}}" >#{{ pr.number }} {{ pr.title }}</a></span>
             <span class="pull-right">
@@ -15,7 +23,7 @@
         </li>
     </ul>
 
-    <ul class="pulls" ng-if="wallDisplay">
+    <ul class="pulls" ng-if="display === 'wallDisplay'">
         <li ng-repeat="pr in toArray(pulls) | orderBy:'updated_at':descendingOrder" ng-class="pr.statuses[0].state" class="status">
             <img class="avatar" ng-src="{{ pr.user.avatar_url}}" title="{{ pr.user.login }}" />
             <div class="pull-number"><a ng-href="{{pr.html_url}}" >#{{ pr.number }}</a></div>

--- a/app/views/main.html
+++ b/app/views/main.html
@@ -3,8 +3,8 @@
   <select ng-model="team" ng-options="teamName as teamName for (teamName, team) in teams"></select>
 </header>
 
-<div class="container">
-    <ul class="pulls">
+<div class="container" ng-class="{'wall-display': wallDisplay}">
+    <ul class="pulls" ng-if="!wallDisplay">
         <li ng-repeat="pr in toArray(pulls) | orderBy:'updated_at':descendingOrder" ng-class="pr.statuses[0].state" class="status">
             <span class="link"><img class="avatar" ng-src="{{ pr.user.avatar_url}}" title="{{ pr.user.login }}" /><a ng-href="{{pr.html_url}}" >#{{ pr.number }} {{ pr.title }}</a></span>
             <span class="pull-right">
@@ -12,6 +12,18 @@
                 <span class="date">{{pr.updated_at | date:"dd/MM/yyyy"}}</span>
             </span>
             <div class="clearer">&nbsp;</div>
+        </li>
+    </ul>
+
+    <ul class="pulls" ng-if="wallDisplay">
+        <li ng-repeat="pr in toArray(pulls) | orderBy:'updated_at':descendingOrder" ng-class="pr.statuses[0].state" class="status">
+            <img class="avatar" ng-src="{{ pr.user.avatar_url}}" title="{{ pr.user.login }}" />
+            <div class="pull-number"><a ng-href="{{pr.html_url}}" >#{{ pr.number }}</a></div>
+            <div class="labels">
+                <span ng-if="!pr.labels.length">&nbsp;</span>
+                <span class="label" ng-repeat="label in pr.labels" ng-style="{'background-color': '#' + label.color, 'color': '#' + getVisibleTextColor(label.color)}">{{label.name}}</span>
+            </div>
+            <div class="repo"><a ng-href="{{pr.head.repo.html_url}}" >{{ pr.head.repo.name }}</a></div>
         </li>
     </ul>
 </div>

--- a/config/config.json.dist
+++ b/config/config.json.dist
@@ -10,7 +10,6 @@
                 "token": "apiToken",
                 "descendingOrder": true
             }
-        },
-        "wallDisplay": false
+        }
     }
 }

--- a/config/config.json.dist
+++ b/config/config.json.dist
@@ -10,6 +10,7 @@
                 "token": "apiToken",
                 "descendingOrder": true
             }
-        }
+        },
+        "fetchAndDisplayTags": true
     }
 }

--- a/config/config.json.dist
+++ b/config/config.json.dist
@@ -11,6 +11,6 @@
                 "descendingOrder": true
             }
         },
-        "fetchAndDisplayTags": true
+        "fetchAndDisplayTags": false
     }
 }

--- a/config/config.json.dist
+++ b/config/config.json.dist
@@ -10,6 +10,7 @@
                 "token": "apiToken",
                 "descendingOrder": true
             }
-        }
+        },
+        "wallDisplay": false
     }
 }

--- a/test/e2e/main.js
+++ b/test/e2e/main.js
@@ -79,6 +79,7 @@ describe('Test GTR screen', function () {
       backend.whenGET('/api/v3/repos/m6web/service-polls/pulls').respond([{
         'id': 6467,
         'html_url': 'http://example.com/m6web/service-polls/pull/54',
+        'issue_url': '/api/v3/repos/m6web/service-polls/issues/54',
         'number': 54,
         'title': 'PR 54',
         'state': 'open',
@@ -102,6 +103,7 @@ describe('Test GTR screen', function () {
       {
         'id': 6468,
         'html_url': 'http://example.com/m6web/service-polls/pull/55',
+        'issue_url': '/api/v3/repos/m6web/service-polls/issues/55',
         'number': 55,
         'title': 'PR 55',
         'state': 'open',
@@ -125,6 +127,7 @@ describe('Test GTR screen', function () {
       {
         'id': 6469,
         'html_url': 'http://example.com/m6web/service-polls/pull/56',
+        'issue_url': '/api/v3/repos/m6web/service-polls/issues/56',
         'number': 56,
         'title': 'PR 56',
         'state': 'open',
@@ -148,6 +151,7 @@ describe('Test GTR screen', function () {
       backend.whenGET('/api/v3/repos/replay/bundle-polls-client/pulls').respond([{
         'id': 5895,
         'html_url': 'http://example.com/replay/bundle-polls-client/pull/49',
+        'issue_url': '/api/v3/repos/replay/bundle-polls-client/issues/49',
         'number': 49,
         'title': 'PR 49',
         'state': 'open',
@@ -171,6 +175,7 @@ describe('Test GTR screen', function () {
       {
         'id': 5896,
         'html_url': 'http://example.com/replay/bundle-polls-client/pull/50',
+        'issue_url': '/api/v3/repos/replay/bundle-polls-client/issues/50',
         'number': 50,
         'title': 'PR 50',
         'state': 'open',
@@ -206,6 +211,23 @@ describe('Test GTR screen', function () {
       backend.whenGET('/api/v3/repos/replay/bundle-polls-client/statuses/50').respond([{
         'state': 'pending'
       }]);
+
+      // Issues (for labels)
+      backend.whenGET('/api/v3/repos/m6web/service-polls/issues/54').respond({
+        labels: [{name: 'bug', color: 'E11D21' }]
+      });
+      backend.whenGET('/api/v3/repos/m6web/service-polls/issues/55').respond({
+        labels: [{name: 'discussion', color: 'BFE5BF' }]
+      });
+      backend.whenGET('/api/v3/repos/m6web/service-polls/issues/56').respond({
+        labels: []
+      });
+      backend.whenGET('/api/v3/repos/replay/bundle-polls-client/issues/49').respond({
+        labels: []
+      });
+      backend.whenGET('/api/v3/repos/replay/bundle-polls-client/issues/50').respond({
+        labels: []
+      });
 
       // Others
       backend.whenGET(/.*/).passThrough();


### PR DESCRIPTION
Hello,

I added for my intended use of this project a wall display (like jenkins') - a display which can show a maximum of useful information even far from the screen.

The idea is to allow a quick preview of a maximum of PR statuses, clearly visible on a screen from afar, and by the entire team.
So this puts mainly the focus on pull requests' numbers, creator and status, with additional information being the project name and labels. Ideally, it'd be cool to be able to configure what information is displayed, but that's another feature.

In order to keep the current look while adding this one, I implemented it with a client-side config switch - to either display the Github Team Reviewer in "list" or "wall display" mode.

I don't know if this is something you'd like for the project, but I thought I'd try sending a pull request before thinking of switching on my fork :)