### PR TITLE
Move Gulp package in standard dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "github-team-reviewer",
   "version": "0.0.0",
   "dependencies": {
-    "bower": "~1.3.12"
+    "bower": "~1.3.12",
+    "gulp": "^3.8.0"
   },
   "devDependencies": {
     "browser-sync": "^1.3.6",
     "chalk": "^0.4.0",
     "del": "^0.1.3",
-    "gulp": "^3.8.0",
     "gulp-csso": "^0.2.6",
     "gulp-filter": "^1.0.0",
     "gulp-inject": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,10 @@
   "version": "0.0.0",
   "dependencies": {
     "bower": "~1.3.12",
-    "gulp": "^3.8.0"
-  },
-  "devDependencies": {
     "browser-sync": "^1.3.6",
     "chalk": "^0.4.0",
     "del": "^0.1.3",
+    "gulp": "^3.8.0",
     "gulp-csso": "^0.2.6",
     "gulp-filter": "^1.0.0",
     "gulp-inject": "^1.0.0",
@@ -20,28 +18,30 @@
     "gulp-ng-config": "^0.1.7",
     "gulp-ng-html2js": "^0.1.6",
     "gulp-protractor": "^0.0.11",
-    "gulp-rename": "^1.2.0",
     "gulp-rev": "^1.1.0",
     "gulp-rev-replace": "^0.3.0",
     "gulp-size": "^1.1.0",
+    "gulp-rename": "^1.2.0",
     "gulp-uglify": "^1.0.0",
     "gulp-useref": "^1.0.0",
     "http-proxy": "^1.3.0",
-    "httpbackend": "^0.5.0",
     "jshint-stylish": "^0.4.0",
-    "karma-jasmine": "^0.1.5",
-    "karma-phantomjs-launcher": "^0.1.4",
     "main-bower-files": "^2.0.0",
-    "protractor": "^1.1.1",
     "require-dir": "^0.1.0",
     "run-sequence": "^1.0.1",
     "uglify-save-license": "^0.4.1",
     "wiredep": "^1.8.5"
   },
+  "devDependencies": {
+    "httpbackend": "^0.5.0",
+    "karma-jasmine": "^0.1.5",
+    "karma-phantomjs-launcher": "^0.1.4",
+    "protractor": "^1.1.1"
+  },
   "engines": {
     "node": ">=0.10.0"
   },
   "scripts": {
-    "test": "grunt test"
+    "test": "gulp test"
   }
 }


### PR DESCRIPTION
Since our deployment system has been updated, we have to provide our own Gulp binary. But Gulp is loaded only for dev environment and then be don't loaded while deployment.