### PR TITLE
Adds labels and milestones display to PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Options :
   * *org* : an array of Github organizations,
   * *apiUrl* : url of your Github API (optional, default is `https://api.github.com`),
   * *descendingOrder* : allow to change ordering of pull requests (optional, default is `true`).
+  * *labels* : display labels of pull requests (optional, default is `false`).
+  * *milestones* : display milestones of pull requests (optional, default is `false`).
   * *token* : authorization token for API calls (optional, it can allow access to more repos and increase API rate limit) NB: if a token is set, OAuth will be ignored for the team
   * *oauthAppClientId* : clientId of the OAuth app the team depends on (optional)
 * **githubOAuth** : OAuth config (optional)

--- a/app/scripts/controllers/main.js
+++ b/app/scripts/controllers/main.js
@@ -22,6 +22,18 @@ angular.module('gtrApp')
       $scope.descendingOrder = true;
     }
 
+    if (typeof(config.teams[team].labels) !== 'undefined') {
+      $scope.labels = config.teams[team].labels;
+    } else {
+      $scope.labels = false;
+    }
+
+    if (typeof(config.teams[team].milestones) !== 'undefined') {
+      $scope.milestones = config.teams[team].milestones;
+    } else {
+      $scope.milestones = false;
+    }
+
     var statePriorities = {
       'error':   4,
       'failure': 3,

--- a/app/scripts/services/pullFetcher.js
+++ b/app/scripts/services/pullFetcher.js
@@ -71,10 +71,26 @@ angular.module('gtrApp')
         });
       };
 
+      var addLabelsToPull = function (pull) {
+        return request(pull.issue_url + '/labels').then(function (response) {
+          pull.labels = response.data;
+        });
+      };
+
+      var removeMilestoneToPull = function (pull) {
+        pull.milestone = null;
+      };
+
       var getRepoPulls = function (repo) {
         return request(repo.pulls_url.replace('{/number}', ''))
           .then(function (response) {
             var filtered = response.data.filter(filterPulls);
+            if (currentTeam.labels) {
+              filtered.map(addLabelsToPull);
+            }
+            if (!currentTeam.milestones) {
+              filtered.map(removeMilestoneToPull);
+            }
 
             return $q.all(filtered.map(addStatusToPull)).then(function() {
               return filtered;

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -175,6 +175,7 @@ ul {
   padding: 4px 8px;
   border-radius: 4px;
   font-size: 0.875em;
+  color: black;
 }
 
 .badge-label {
@@ -183,6 +184,5 @@ ul {
 
 .badge-milestone {
   background-color: white;
-  color: black;
   margin-right: 4px;
 }

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -170,3 +170,19 @@ ul {
 .pr-counter {
   margin-right: 10px;
 }
+
+.badge {
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.875em;
+}
+
+.badge-label {
+  margin-left: 4px;
+}
+
+.badge-milestone {
+  background-color: white;
+  color: black;
+  margin-right: 4px;
+}

--- a/app/views/main.html
+++ b/app/views/main.html
@@ -19,8 +19,13 @@
 <div class="container">
     <ul class="pulls">
         <li ng-repeat="pr in toArray(pulls) | orderBy:'updated_at':descendingOrder" ng-class="pr.statuses[0].state" class="status">
-            <span class="link"><img class="avatar" ng-src="{{ pr.user.avatar_url}}" title="{{ pr.user.login }}" /><a ng-href="{{pr.html_url}}" >#{{ pr.number }} {{ pr.title }}</a></span>
+            <span class="link">
+                <img class="avatar" ng-src="{{ pr.user.avatar_url}}" title="{{ pr.user.login }}" />
+                <a ng-href="{{pr.html_url}}" >#{{ pr.number }} {{ pr.title }}</a>
+                <span class="badge badge-label" ng-repeat="label in toArray(pr.labels)" style="background-color: #{{ label.color }}">{{ label.name }}</span>
+            </span>
             <span class="pull-right">
+                <span class="badge badge-milestone" ng-show="pr.milestone != null">{{ pr.milestone.title }}</span>
                 <span class="repo"><a ng-href="{{pr.head.repo.html_url}}" >{{ pr.head.repo.full_name }}</a></span>
                 <span class="date">{{pr.updated_at | date:"dd/MM/yyyy"}}</span>
             </span>

--- a/config/config.json.dist
+++ b/config/config.json.dist
@@ -7,7 +7,9 @@
                 "projects": ["repo1", "repo2"],
                 "orgs": ["orgname1", "orgname2"],
                 "token": "apiToken",
-                "descendingOrder": true
+                "descendingOrder": true,
+                "labels": true,
+                "milestones": true
             },
             "teamWithOAuth": {
                 "members": ["username4", "username2", "username5"],

--- a/config/config_test.json
+++ b/config/config_test.json
@@ -23,13 +23,15 @@
             "burton": {
                 "members": ["papy", "worker"],
                 "orgs": ["m6web"],
-                "apiUrl": "/api/v3"
+                "apiUrl": "/api/v3",
+                "labels": true
             },
             "service-polls": {
                 "descendingOrder": false,
                 "projects": ["service-polls"],
                 "orgs": ["m6web", "replay"],
-                "apiUrl": "/api/v3"
+                "apiUrl": "/api/v3",
+                "milestones": true
             }
         }
     }

--- a/test/e2e/main.js
+++ b/test/e2e/main.js
@@ -50,22 +50,6 @@ describe('Test GTR screen', function () {
       element(by.cssContainingText('header select option', 'burton')).click();
       expect(browser.getLocationAbsUrl()).toBe('/burton');
     });
-
-    it('should not display labels and milestones by default', function () {
-      browser.get('#/cytron');
-      expect(element(by.css('.pulls li:eq(0) .badge-label')).isPresent()).toBe(false);
-      expect(element(by.css('.pulls li:eq(0) .badge-milestone')).isPresent()).toBe(false);
-    });
-
-    it('should display labels when enabled', function () {
-      browser.get('#/burton');
-      expect(element(by.css('.pulls li:eq(0) .badge-label')).isPresent()).toBe(true);
-    });
-
-    it('should display milestones when enabled', function () {
-      browser.get('#/service-polls');
-      expect(element(by.css('.pulls li:eq(2) .badge-milestone')).isPresent()).toBe(true);
-    });
   });
 
   describe('Test with API calls', function () {
@@ -140,8 +124,8 @@ describe('Test GTR screen', function () {
             'name': 'service-polls'
           }
         },
-        "milestone": {
-          "title": "release-1.0.0"
+        'milestone': {
+          'title': 'release-1.1.0'
         }
       },
       {
@@ -167,8 +151,8 @@ describe('Test GTR screen', function () {
             'name': 'service-polls'
           }
         },
-        "milestone": {
-          "title": "release-1.0.0"
+        'milestone': {
+          'title': 'release-1.0.0'
         }
       }]);
       backend.whenGET('/api/v3/repos/replay/bundle-polls-client/pulls').respond([{
@@ -253,14 +237,8 @@ describe('Test GTR screen', function () {
       // Labels
       backend.whenGET('/api/v3/repos/m6web/service-polls/issues/55/labels').respond([
         {
-          "name": "need_review",
-          "color": "b60205"
-        }
-      ]);
-      backend.whenGET('/api/v3/repos/m6web/service-polls/issues/56/labels').respond([
-        {
-          "name": "do_not_merge",
-          "color": "ff0000"
+          'name': 'need_review',
+          'color': 'b60205'
         }
       ]);
 
@@ -332,7 +310,7 @@ describe('Test GTR screen', function () {
 
       expect(pulls).toEqual([{
           index: 0,
-          text: '#55 PR 55\nm6web/service-polls 28/08/2014',
+          text: '#55 PR 55 need_review\nm6web/service-polls 28/08/2014',
           class: '',
           avatar: 'http://example.com/papy.jpg',
           pullUrl: 'http://example.com/m6web/service-polls/pull/55'
@@ -354,14 +332,14 @@ describe('Test GTR screen', function () {
         },
         {
           index: 1,
-          text: '#55 PR 55\nm6web/service-polls 28/08/2014',
+          text: '#55 PR 55\nrelease-1.1.0 m6web/service-polls 28/08/2014',
           class: '',
           avatar: 'http://example.com/papy.jpg',
           pullUrl: 'http://example.com/m6web/service-polls/pull/55'
         },
         {
           index: 2,
-          text: '#56 PR 56\nm6web/service-polls 28/10/2014',
+          text: '#56 PR 56\nrelease-1.0.0 m6web/service-polls 28/10/2014',
           class: 'success',
           avatar: 'http://example.com/bieber.jpg',
           pullUrl: 'http://example.com/m6web/service-polls/pull/56'

--- a/test/e2e/main.js
+++ b/test/e2e/main.js
@@ -50,6 +50,22 @@ describe('Test GTR screen', function () {
       element(by.cssContainingText('header select option', 'burton')).click();
       expect(browser.getLocationAbsUrl()).toBe('/burton');
     });
+
+    it('should not display labels and milestones by default', function () {
+      browser.get('#/cytron');
+      expect(element(by.css('.pulls li:eq(0) .badge-label')).isPresent()).toBe(false);
+      expect(element(by.css('.pulls li:eq(0) .badge-milestone')).isPresent()).toBe(false);
+    });
+
+    it('should display labels when enabled', function () {
+      browser.get('#/burton');
+      expect(element(by.css('.pulls li:eq(0) .badge-label')).isPresent()).toBe(true);
+    });
+
+    it('should display milestones when enabled', function () {
+      browser.get('#/service-polls');
+      expect(element(by.css('.pulls li:eq(2) .badge-milestone')).isPresent()).toBe(true);
+    });
   });
 
   describe('Test with API calls', function () {
@@ -79,6 +95,7 @@ describe('Test GTR screen', function () {
       backend.whenGET('/api/v3/repos/m6web/service-polls/pulls').respond([{
         'id': 6467,
         'html_url': 'http://example.com/m6web/service-polls/pull/54',
+        'issue_url': '/api/v3/repos/m6web/service-polls/issues/54',
         'number': 54,
         'title': 'PR 54',
         'state': 'open',
@@ -97,11 +114,13 @@ describe('Test GTR screen', function () {
             'full_name': 'm6web/service-polls',
             'name': 'service-polls'
           }
-        }
+        },
+        'milestone': null
       },
       {
         'id': 6468,
         'html_url': 'http://example.com/m6web/service-polls/pull/55',
+        'issue_url': '/api/v3/repos/m6web/service-polls/issues/55',
         'number': 55,
         'title': 'PR 55',
         'state': 'open',
@@ -120,11 +139,15 @@ describe('Test GTR screen', function () {
             'full_name': 'm6web/service-polls',
             'name': 'service-polls'
           }
+        },
+        "milestone": {
+          "title": "release-1.0.0"
         }
       },
       {
         'id': 6469,
         'html_url': 'http://example.com/m6web/service-polls/pull/56',
+        'issue_url': '/api/v3/repos/m6web/service-polls/issues/56',
         'number': 56,
         'title': 'PR 56',
         'state': 'open',
@@ -143,11 +166,15 @@ describe('Test GTR screen', function () {
             'full_name': 'm6web/service-polls',
             'name': 'service-polls'
           }
+        },
+        "milestone": {
+          "title": "release-1.0.0"
         }
       }]);
       backend.whenGET('/api/v3/repos/replay/bundle-polls-client/pulls').respond([{
         'id': 5895,
         'html_url': 'http://example.com/replay/bundle-polls-client/pull/49',
+        'issue_url': '/api/v3/repos/replay/bundle-polls-client/issues/49',
         'number': 49,
         'title': 'PR 49',
         'state': 'open',
@@ -166,11 +193,13 @@ describe('Test GTR screen', function () {
             'full_name': 'replay/bundle-polls-client',
             'name': 'bundle-polls-client'
           }
-        }
+        },
+        'milestone': null
       },
       {
         'id': 5896,
         'html_url': 'http://example.com/replay/bundle-polls-client/pull/50',
+        'issue_url': '/api/v3/repos/replay/bundle-polls-client/issues/50',
         'number': 50,
         'title': 'PR 50',
         'state': 'open',
@@ -189,7 +218,8 @@ describe('Test GTR screen', function () {
             'full_name': 'replay/bundle-polls-client',
             'name': 'bundle-polls-client'
           }
-        }
+        },
+        'milestone': null
       }]);
 
       //Statuses
@@ -219,6 +249,20 @@ describe('Test GTR screen', function () {
         'context': 'foobar',
         'state': 'success'
       }]);
+
+      // Labels
+      backend.whenGET('/api/v3/repos/m6web/service-polls/issues/55/labels').respond([
+        {
+          "name": "need_review",
+          "color": "b60205"
+        }
+      ]);
+      backend.whenGET('/api/v3/repos/m6web/service-polls/issues/56/labels').respond([
+        {
+          "name": "do_not_merge",
+          "color": "ff0000"
+        }
+      ]);
 
       // Others
       backend.whenGET(/.*/).passThrough();


### PR DESCRIPTION
Adds display of labels and milestones (separately) from Github Pull Requests:
- Displays the label inside a badge with his name as content, and his color as background-color
- Displays the milestone inside a badge with a background-color at white, and color at black (to the right)
- You can disable them in config.json inside your team config (default: enabled)